### PR TITLE
Update to zeit.co/now 2.0

### DIFF
--- a/generate-token.js
+++ b/generate-token.js
@@ -1,0 +1,12 @@
+const jwt = require('jsonwebtoken');
+
+// Generate an Access Token for the given User ID
+module.exports = function generateJwt(user) {
+  const token = jwt.sign(user, process.env.SESSION_SECRET, {
+    expiresIn: 86400 * 30,
+    audience: 'geojsonnet',
+    issuer: 'geojsonnet'
+  });
+
+  return token;
+}

--- a/now.json
+++ b/now.json
@@ -1,5 +1,16 @@
 {
+  "version": 2,
+  "name": "geojson.net",
   "alias": "geojson.net",
+  "builds": [
+    {"src": "package.json", "use": "@now/static-build", "config": { "newPipeline": true }},
+    {"src": "server.js", "use": "@now/node-server", "config": { "newPipeline": true }}
+  ],
+  "routes": [
+    { "src": "/github/.*", "dest": "/server.js"},
+    { "src": "/auth/.*", "dest": "/server.js"},
+    { "src": "/(.*)", "dest": "/$1"}
+  ],
   "env": {
     "NODE_ENV": "production",
     "GITHUB_CLIENT_ID": "@geojsonnet-github-client-id",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-runtime": "^6.26.0",
     "bowser": "1.9.4",
     "codemirror": "^5.37.0",
+    "cookie-parser": "^1.4.3",
     "csv2geojson": "5.0.2",
     "deep-equal": "^1.0.1",
     "detect-json-indent": "0.0.3",
@@ -29,6 +30,7 @@
     "escape-html": "^1.0.1",
     "express": "^4.16.3",
     "express-http-proxy": "^1.2.0",
+    "express-jwt": "^5.3.1",
     "express-session": "^1.15.6",
     "file-saver": "^1.3.8",
     "geojson-extent": "^0.3.1",
@@ -40,6 +42,7 @@
     "graphql-tag": "^2.9.2",
     "gtfs2geojson": "^2.0.0",
     "json-stringify-pretty-compact": "^1.1.0",
+    "jsonwebtoken": "^8.4.0",
     "leaflet": "^1.3.1",
     "leaflet-editable": "^1.1.0",
     "leaflet-geodesy": "0.2.1",
@@ -48,6 +51,7 @@
     "parcel-bundler": "^1.8.1",
     "passport": "^0.4.0",
     "passport-github": "^1.1.0",
+    "passport-jwt": "^4.0.0",
     "polyline": "^0.2.0",
     "polytogeojson": "0.0.1",
     "prettier": "1.13.7",
@@ -78,7 +82,8 @@
     "start": "node server.js",
     "build": "parcel build index.html",
     "test": "jest",
-    "storybook": "start-storybook -p 9001"
+    "storybook": "start-storybook -p 9001",
+    "now-build": "yarn build"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -210,7 +210,7 @@ class App extends React.Component {
                 </div>
               )}
               {githubModal && (
-                <GithubModal toggleGithubModal={this.toggleGithubModal} />
+                <GithubModal toggleGithubModal={this.toggleGithubModal} setGeojson={setGeojson} />
               )}
               {gistModal && <GistModal />}
               {layerModal && (

--- a/src/ui/github_modal.js
+++ b/src/ui/github_modal.js
@@ -63,7 +63,7 @@ const TEXT_QUERY = gql`
   }
 `;
 
-const Import = ({ id }) => (
+const Import = ({ id, importGithub }) => (
   <Query query={TEXT_QUERY} variables={{ id }}>
     {({ loading, error, data }) =>
       loading ? (
@@ -77,7 +77,7 @@ const Import = ({ id }) => (
           </div>
           <div
             className="pa2 hover-bg-yellow bt pointer"
-            onClick={() => this.props.importFiles(data.node.text)}
+            onClick={() => importGithub(data.node.text)}
           >
             Import
           </div>
@@ -175,7 +175,7 @@ const RepoBrowser = ({ setRepository }) => (
   </Query>
 );
 
-export default class extends React.Component {
+export default class GithubModal extends React.Component {
   state = {
     organization: undefined,
     repository: undefined,
@@ -197,6 +197,17 @@ export default class extends React.Component {
       // enter tree.
     }
   };
+
+  importGithub = text => {
+    try {
+      console.log(text);
+      const json = JSON.parse(text);
+      this.props.setGeojson(json);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   render() {
     const { repository, prospectiveImportId } = this.state;
     const { toggleGithubModal } = this.props;
@@ -216,6 +227,7 @@ export default class extends React.Component {
           <div
             className="bg-white flex items-stretch ba"
             style={{
+              maxHeight: '85vh',
               zIndex: 999
             }}
           >
@@ -224,7 +236,7 @@ export default class extends React.Component {
             {repository && (
               <FileBrowser repository={repository} clickFile={clickFile} />
             )}
-            {prospectiveImportId && <Import id={prospectiveImportId} />}
+            {prospectiveImportId && <Import id={prospectiveImportId} importGithub={this.importGithub} />}
           </div>
           <span
             onClick={toggleGithubModal}

--- a/src/ui/user.js
+++ b/src/ui/user.js
@@ -58,10 +58,7 @@ export default class User extends React.Component {
               {data.viewer.login}
               <a
                 className="ph2 pointer hover-bg-yellow pa2 ml2"
-                onClick={() => {
-                  localStorage.removeItem("githubToken");
-                  location.reload();
-                }}
+                href="/auth/github/logout"
               >
                 logout
               </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,6 +2099,10 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+
 buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
@@ -2765,6 +2769,14 @@ conventional-recommended-bump@^1.0.0:
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+
+cookie-parser@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.3.tgz#0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5"
+  integrity sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -3475,6 +3487,12 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+ecdsa-sig-formatter@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
+  dependencies:
+    safe-buffer "^5.0.1"
+
 editorconfig@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
@@ -3823,6 +3841,15 @@ express-http-proxy@^1.2.0:
     es6-promise "^4.1.1"
     raw-body "^2.3.0"
 
+express-jwt@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-5.3.1.tgz#66f05c7dddb5409c037346a98b88965bb10ea4ae"
+  dependencies:
+    async "^1.5.0"
+    express-unless "^0.3.0"
+    jsonwebtoken "^8.1.0"
+    lodash.set "^4.0.0"
+
 express-session@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.15.6.tgz#47b4160c88f42ab70fe8a508e31cbff76757ab0a"
@@ -3836,6 +3863,10 @@ express-session@^1.15.6:
     parseurl "~1.3.2"
     uid-safe "~2.1.5"
     utils-merge "1.0.1"
+
+express-unless@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/express-unless/-/express-unless-0.3.1.tgz#2557c146e75beb903e2d247f9b5ba01452696e20"
 
 express@^4.16.3:
   version "4.16.3"
@@ -5852,6 +5883,20 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
 
+jsonwebtoken@^8.1.0, jsonwebtoken@^8.2.0, jsonwebtoken@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz#8757f7b4cb7440d86d5e2f3becefa70536c8e46a"
+  dependencies:
+    jws "^3.1.5"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -5866,6 +5911,21 @@ jszip@2.5.0:
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-2.5.0.tgz#7444fd8551ddf3e5da7198fea0c91bc8308cc274"
   dependencies:
     pako "~0.2.5"
+
+jwa@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.2.0.tgz#606da70c1c6d425cad329c77c99f2df2a981489a"
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.10"
+    safe-buffer "^5.0.1"
+
+jws@^3.1.5:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.1.tgz#d79d4216a62c9afa0a3d5e8b5356d75abdeb2be5"
+  dependencies:
+    jwa "^1.2.0"
+    safe-buffer "^5.0.1"
 
 jxon@~2.0.0-beta.5:
   version "2.0.0-beta.5"
@@ -6044,6 +6104,10 @@ lodash.flow@^3.3.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -6052,9 +6116,25 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
 
 lodash.keys@^3.1.2:
   version "3.1.2"
@@ -6068,9 +6148,17 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+
 lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.set@^4.0.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
 
 lodash.some@^4.6.0:
   version "4.6.0"
@@ -6495,7 +6583,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -7143,6 +7231,14 @@ passport-github@^1.1.0:
   dependencies:
     passport-oauth2 "1.x.x"
 
+passport-jwt@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/passport-jwt/-/passport-jwt-4.0.0.tgz#7f0be7ba942e28b9f5d22c2ebbb8ce96ef7cf065"
+  integrity sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==
+  dependencies:
+    jsonwebtoken "^8.2.0"
+    passport-strategy "^1.0.0"
+
 passport-oauth2@1.x.x:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/passport-oauth2/-/passport-oauth2-1.4.0.tgz#f62f81583cbe12609be7ce6f160b9395a27b86ad"
@@ -7152,7 +7248,7 @@ passport-oauth2@1.x.x:
     uid2 "0.0.x"
     utils-merge "1.x.x"
 
-passport-strategy@1.x.x:
+passport-strategy@1.x.x, passport-strategy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
 


### PR DESCRIPTION
Zeit's now has upgraded to 2.0. 
This updates the now.json to use version 2.
now 2.0 runs on aws lambda, which means the server needs to be stateless, and not use memory session.
To make the server stateless, and not need a database for sessions, I implemented a jwt cookie authentication.

While testing the new authentication, I found the github import function was not hooked up anymore. I added the basic geojson functionality, but this will still need more UI will be needed for error handling, and handling of wkt and esri shapefiles.

[PR example](https://geojsonnet-mkbwlm3pv.now.sh/#2/20.0/0.0)